### PR TITLE
Fix: Improve tree parsing error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Must-have:
 
 Should-have:
 
+- [ ] Add hashes of build results (where possible).
 - [ ] (Optionally) Add source artefacts as "GENERATED_FROM" relationship.
 - [ ] Treat internal (=non-OSS) packages differently for output SBOM.
 - [ ] Support output "flavors" for the purpose of the generated SBOM.

--- a/src/main/java/com/philips/research/spdxbuilder/core/BusinessException.java
+++ b/src/main/java/com/philips/research/spdxbuilder/core/BusinessException.java
@@ -12,4 +12,8 @@ public class BusinessException extends RuntimeException {
     public BusinessException(String message) {
         super(message);
     }
+
+    public BusinessException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/src/main/java/com/philips/research/spdxbuilder/persistence/spdx/SpdxWriter.java
+++ b/src/main/java/com/philips/research/spdxbuilder/persistence/spdx/SpdxWriter.java
@@ -85,7 +85,7 @@ public class SpdxWriter implements BomWriter {
     }
 
     private void writePackage(TagValueDocument doc, Package pkg, BillOfMaterials bom) throws IOException {
-        doc.addComment("Start of package '" + pkg);
+        doc.addComment("Start of package " + pkg);
         doc.addValue("PackageName", pkg.getFullName());
         doc.addValue("SPDXID", identifierFor(pkg));
         doc.addValue("PackageVersion", pkg.getVersion());

--- a/src/main/java/com/philips/research/spdxbuilder/persistence/tree/TreeException.java
+++ b/src/main/java/com/philips/research/spdxbuilder/persistence/tree/TreeException.java
@@ -11,4 +11,8 @@ public class TreeException extends BusinessException {
     public TreeException(String message) {
         super(message);
     }
+
+    public TreeException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/src/main/java/com/philips/research/spdxbuilder/persistence/tree/TreeParser.java
+++ b/src/main/java/com/philips/research/spdxbuilder/persistence/tree/TreeParser.java
@@ -311,11 +311,15 @@ class TreeParser {
     }
 
     private PackageURL purlFromLine(String line) {
-        final var type = extractType(line);
-        final var namespace = match(namespacePattern, line, namespaceGroup);
-        final var name = match(namePattern, line, nameGroup);
-        final var version = match(versionPattern, line, versionGroup);
-        return toPurl(type, namespace, name, version);
+        try {
+            final var type = extractType(line);
+            final var namespace = match(namespacePattern, line, namespaceGroup);
+            final var name = match(namePattern, line, nameGroup);
+            final var version = match(versionPattern, line, versionGroup);
+            return toPurl(type, namespace, name, version);
+        } catch (Exception e) {
+            throw new TreeException("Unsupported package format: '" + line + "'", e);
+        }
     }
 
     private String extractType(String line) {

--- a/src/test/java/com/philips/research/spdxbuilder/persistence/tree/TreeFormatsTest.java
+++ b/src/test/java/com/philips/research/spdxbuilder/persistence/tree/TreeFormatsTest.java
@@ -118,7 +118,6 @@ class TreeFormatsTest {
                     new Package("@scope", "sub-package", "2.1"));
         }
 
-
         @Test
         void rust() {
             format.configure(parser, "rust");

--- a/src/test/java/com/philips/research/spdxbuilder/persistence/tree/TreeParserTest.java
+++ b/src/test/java/com/philips/research/spdxbuilder/persistence/tree/TreeParserTest.java
@@ -32,7 +32,7 @@ class TreeParserTest {
     @Test
     void throws_missingPackageTypeConfiguration() {
         assertThatThrownBy(() -> parser.parse(PACKAGE1))
-                .hasMessageContaining("type=,");
+                .hasMessageContaining("package format");
     }
 
     @Nested
@@ -53,7 +53,7 @@ class TreeParserTest {
         void throws_incompleteIdentifier() {
             assertThatThrownBy(() -> parser.parse("incomplete"))
                     .isInstanceOf(TreeException.class)
-                    .hasMessageContaining("package identifier");
+                    .hasMessageContaining("package format");
         }
 
         @Test
@@ -120,7 +120,7 @@ class TreeParserTest {
 
             assertThatThrownBy(() -> parser.parse(PACKAGE1 + " [Unknown]"))
                     .isInstanceOf(TreeException.class)
-                    .hasMessageContaining("'Unknown'");
+                    .hasMessageContaining("Unknown");
         }
 
         @Test

--- a/src/test/java/com/philips/research/spdxbuilder/persistence/tree/TreeReaderTest.java
+++ b/src/test/java/com/philips/research/spdxbuilder/persistence/tree/TreeReaderTest.java
@@ -74,7 +74,7 @@ class TreeReaderTest {
 
         assertThatThrownBy(() -> reader.read(bom))
                 .isInstanceOf(TreeException.class)
-                .hasMessageContaining("package identifier");
+                .hasMessageContaining("package format");
     }
 
     @NotNull


### PR DESCRIPTION
Was (often) a list of empty PURL elements, so wrapped the exception with one that indicates the line where the problem occurs.