### PR TITLE
Feature/work in progress builds

### DIFF
--- a/docs/usage_with_tree.md
+++ b/docs/usage_with_tree.md
@@ -14,12 +14,22 @@ the [BOM-Base](https://github.com/philips-software/bom-base) knowledge base
 instance that supplies the metadata for the packages parsed from the dependency
 tree.
 
+_Note: Configuration information (see below) is read from a file
+named `.spdx-builder.yml`. This name can be overridden on the command line._
+
 _Note: The list of supported formats is output when no format option is
 specified._
 
 _Note: If no "output_file" is specified, the output is written to a file named
 `bom.spdx` in the current directory. If the file has no extension, `.spdx`
 is automatically appended._
+
+Root packages of the tree are by default exported without a package URL to
+indicate they are not (yet) public. This can be overridden by the `--release`
+option on the command line. Some formats allow for deriving internal packages
+from the parsed tree structure, else additional internal packages can be
+indicated in the configuration file by package URLs that may contain "*" as
+wildcard.
 
 When a project consists of multiple trees, a pre-processing script can be used
 to first merge the generated trees into a single input to SPDX-Builder. If the
@@ -28,6 +38,27 @@ a `### <new_format` marker fragment (that can be anywhere in the line) to switch
 to a different tree format. The tree indentation level is maintained across
 format changes, making it even possible (by adding indents) to insert a sub-tree
 in a different format.
+
+## Configuration file format
+
+```yaml
+document:
+  title: <string> # Name of the product (=root of the tree)
+  organization: <string> # Organization publishing the SBOM
+  comment: <string> # (Optional) document level comment text
+  key: <string> # (Optional) document reference (is appendended to "SPDXRef-")
+  namespace: <url> # (Optional) base URL of the SPDX document namespace
+internal: # Package URL globs to match any product-internal packages
+  - <string> # (Simplified) package URL glob with optional "*" wildcards
+```
+
+Simplified package URL globs can take various forms:
+
+- `type/namespace/name@version`: Exact match ("pkg:" prefix is optional)
+- `type/namespace/name`: Matches any version
+- `type/name`: Matches any namespace
+- `name`: Matches any type and any namespace
+- 'so*ng': Matches names like "something" or "song" (but not "songs")
 
 ## Supported trees
 

--- a/spdx-tree.yml
+++ b/spdx-tree.yml
@@ -1,6 +1,0 @@
-document:
-  title: "SPDX-Builder command line tool"
-  organization: "Philips Research"
-  comment: "This is an experimental tool"
-  key:
-  namespace: "https://research.philips.com/spdx-builder"

--- a/src/main/java/com/philips/research/spdxbuilder/controller/TreeCommand.java
+++ b/src/main/java/com/philips/research/spdxbuilder/controller/TreeCommand.java
@@ -41,6 +41,9 @@ public class TreeCommand extends AbstractCommand {
     @CommandLine.Option(names = {"--kb", "--bombase"}, description = "Add package metadata from BOM-base knowledge base", paramLabel = "SERVER_URL")
     @NullOr URI bomBase;
 
+    @CommandLine.Option(names = {"--release"}, description = "Root packages expose their package URL", defaultValue = "false")
+    boolean isRelease;
+
     @Override
     public void run() {
         if (format == null) {
@@ -54,7 +57,8 @@ public class TreeCommand extends AbstractCommand {
     @Override
     protected ConversionService createService() {
         final var config = readConfiguration();
-        final BomReader reader = new TreeReader(System.in, format, formatExtension, config.getInternalGlobs());
+        final BomReader reader = new TreeReader(System.in, format, formatExtension, config.getInternalGlobs())
+                .setRelease(isRelease);
         final BomWriter writer = new SpdxWriter(spdxFile);
 
         final var service = bomBase != null

--- a/src/main/java/com/philips/research/spdxbuilder/core/domain/BillOfMaterials.java
+++ b/src/main/java/com/philips/research/spdxbuilder/core/domain/BillOfMaterials.java
@@ -18,7 +18,7 @@ public class BillOfMaterials {
     private final Set<Relation> relations = new HashSet<>();
     private @NullOr String title;
     private @NullOr String comment;
-    private @NullOr String organization;
+    private @NullOr Party organization;
     private @NullOr String identifier;
     private @NullOr URI namespace;
 
@@ -63,11 +63,11 @@ public class BillOfMaterials {
         return this;
     }
 
-    public Optional<String> getOrganization() {
+    public Optional<Party> getOrganization() {
         return Optional.ofNullable(organization);
     }
 
-    public BillOfMaterials setOrganization(String organization) {
+    public BillOfMaterials setOrganization(Party organization) {
         this.organization = organization;
         return this;
     }

--- a/src/main/java/com/philips/research/spdxbuilder/core/domain/ConversionInteractor.java
+++ b/src/main/java/com/philips/research/spdxbuilder/core/domain/ConversionInteractor.java
@@ -41,7 +41,7 @@ public class ConversionInteractor implements ConversionService {
     @Override
     public void setDocument(String title, String organization) {
         bom.setTitle(title);
-        bom.setOrganization(organization);
+        bom.setOrganization(new Party(Party.Type.ORGANIZATION, organization));
     }
 
     @Override

--- a/src/main/java/com/philips/research/spdxbuilder/core/domain/Package.java
+++ b/src/main/java/com/philips/research/spdxbuilder/core/domain/Package.java
@@ -20,6 +20,7 @@ public final class Package {
     private final String name;
     private final String version;
     private final Map<String, String> hash = new HashMap<>();
+    private final Set<License> detectedLicenses = new HashSet<>();
     private boolean internal;
     private @NullOr PackageURL purl;
     private @NullOr Party supplier;
@@ -29,7 +30,6 @@ public final class Package {
     private @NullOr URL homePage;
     private @NullOr License concludedLicense;
     private @NullOr License declaredLicense;
-    private @NullOr License detectedLicense;
     private @NullOr String copyright;
     private @NullOr String summary;
     private @NullOr String description;
@@ -136,12 +136,7 @@ public final class Package {
     }
 
     public Optional<License> getConcludedLicense() {
-        if (concludedLicense != null) {
-            return Optional.of(concludedLicense);
-        } else if (declaredLicense == null) {
-            return Optional.ofNullable(detectedLicense);
-        }
-        return Optional.of(declaredLicense);
+        return Optional.ofNullable(concludedLicense);
     }
 
     public Package setConcludedLicense(@NullOr License concludedLicense) {
@@ -158,12 +153,14 @@ public final class Package {
         return this;
     }
 
-    public Optional<License> getDetectedLicense() {
-        return Optional.ofNullable(detectedLicense);
+    public Collection<License> getDetectedLicenses() {
+        return detectedLicenses;
     }
 
-    public Package setDetectedLicense(@NullOr License license) {
-        this.detectedLicense = license;
+    public Package addDetectedLicense(License license) {
+        if (license.isDefined()) {
+            this.detectedLicenses.add(license);
+        }
         return this;
     }
 
@@ -220,7 +217,9 @@ public final class Package {
 
     @Override
     public String toString() {
-        return getPurl().map(PackageURL::canonicalize)
+        return getPurl()
+                .filter(p -> !isInternal())
+                .map(PackageURL::canonicalize)
                 .orElse(getFullName() + (version.isBlank() ? "" : " version " + version));
     }
 }

--- a/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckReader.java
+++ b/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckReader.java
@@ -78,7 +78,7 @@ public class BlackDuckReader implements BomReader {
         final var root = new Package("", project.getName(), projectVersion.getName());
         project.getDescription().ifPresent(root::setDescription);
         projectVersion.getDescription().ifPresent(root::setSummary);
-        projectVersion.getLicense().ifPresent(root::setDeclaredLicense);
+        projectVersion.getLicense().ifPresent(root::setConcludedLicense);
         bom.addPackage(root);
 
         final var components = client.getComponents(project.getId(), projectVersion.getId());

--- a/src/main/java/com/philips/research/spdxbuilder/persistence/bom_base/BomBaseApi.java
+++ b/src/main/java/com/philips/research/spdxbuilder/persistence/bom_base/BomBaseApi.java
@@ -13,9 +13,7 @@ import retrofit2.http.Path;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Function;
 
 public interface BomBaseApi {
@@ -81,12 +79,18 @@ public interface BomBaseApi {
         }
 
         @Override
-        public Optional<String> getDetectedLicense() {
-            return getStringAttribute("detected_license");
+        public List<String> getDetectedLicenses() {
+            return getStringListAttribute("detected_licenses");
         }
 
         private Optional<String> getStringAttribute(String tag) {
             return getAttribute(tag, str -> (String) str);
+        }
+
+        private List<String> getStringListAttribute(String tag) {
+            return getAttribute(tag, str -> (String) str)
+                    .map(str -> Arrays.asList(str.split("\n")))
+                    .orElse(List.of());
         }
 
         private Optional<URI> getUriAttribute(String tag) {

--- a/src/main/java/com/philips/research/spdxbuilder/persistence/bom_base/BomBaseKnowledgeBase.java
+++ b/src/main/java/com/philips/research/spdxbuilder/persistence/bom_base/BomBaseKnowledgeBase.java
@@ -33,7 +33,7 @@ public class BomBaseKnowledgeBase extends KnowledgeBase {
                     meta.getSha1().ifPresent(hash -> pkg.addHash("SHA1", hash));
                     meta.getSha256().ifPresent(hash -> pkg.addHash("SHA256", hash));
                     meta.getDeclaredLicense().map(LicenseParser::parse).ifPresent(pkg::setDeclaredLicense);
-                    meta.getDetectedLicense().map(LicenseParser::parse).ifPresent(pkg::setDetectedLicense);
+                    meta.getDetectedLicenses().stream().map(LicenseParser::parse).forEach(pkg::addDetectedLicense);
                     return meta;
                 }).isPresent();
     }

--- a/src/main/java/com/philips/research/spdxbuilder/persistence/bom_base/PackageMetadata.java
+++ b/src/main/java/com/philips/research/spdxbuilder/persistence/bom_base/PackageMetadata.java
@@ -7,6 +7,7 @@ package com.philips.research.spdxbuilder.persistence.bom_base;
 
 import java.net.URI;
 import java.net.URL;
+import java.util.List;
 import java.util.Optional;
 
 public interface PackageMetadata {
@@ -32,5 +33,5 @@ public interface PackageMetadata {
 
     Optional<String> getDeclaredLicense();
 
-    Optional<String> getDetectedLicense();
+    List<String> getDetectedLicenses();
 }

--- a/src/main/java/com/philips/research/spdxbuilder/persistence/license_scanner/LicenseKnowledgeBase.java
+++ b/src/main/java/com/philips/research/spdxbuilder/persistence/license_scanner/LicenseKnowledgeBase.java
@@ -39,7 +39,7 @@ public class LicenseKnowledgeBase extends KnowledgeBase {
                 .map(l -> {
                     final var scanned = LicenseParser.parse(l.getLicense());
                     final var declared = pkg.getDeclaredLicense().orElse(scanned);
-                    pkg.setDetectedLicense(scanned);
+                    pkg.addDetectedLicense(scanned);
                     if (l.isConfirmed()) {
                         pkg.setConcludedLicense(scanned);
                     } else {

--- a/src/main/java/com/philips/research/spdxbuilder/persistence/tree/TreeReader.java
+++ b/src/main/java/com/philips/research/spdxbuilder/persistence/tree/TreeReader.java
@@ -18,6 +18,7 @@ public class TreeReader implements BomReader {
     private final String format;
     private final InputStream stream;
     private final List<String> internalGlobs;
+    private boolean isRelease;
 
     public TreeReader(InputStream stream, String format, @NullOr File extension, List<String> internalGlobs) {
         this.internalGlobs = internalGlobs;
@@ -29,10 +30,18 @@ public class TreeReader implements BomReader {
         this.stream = stream;
     }
 
+    public TreeReader setRelease(boolean enable) {
+        this.isRelease = enable;
+        return this;
+    }
+
     @Override
     public void read(BillOfMaterials bom) {
         try (final var reader = new BufferedReader(new InputStreamReader(stream))) {
             final var parser = new TreeParser(bom);
+            if (isRelease) {
+                parser.withRelease();
+            }
             internalGlobs.forEach(pattern -> parser.withInternal(new PurlGlob(pattern)));
             formats.configure(parser, format);
 

--- a/src/test/java/com/philips/research/spdxbuilder/core/domain/ConversionInteractorTest.java
+++ b/src/test/java/com/philips/research/spdxbuilder/core/domain/ConversionInteractorTest.java
@@ -86,7 +86,7 @@ class ConversionInteractorTest {
         interactor.setComment(COMMENT);
 
         assertThat(bom.getTitle()).isEqualTo(PROJECT);
-        assertThat(bom.getOrganization()).contains(ORGANIZATION);
+        assertThat(bom.getOrganization().orElseThrow().getName()).isEqualTo(ORGANIZATION);
         assertThat(bom.getComment()).contains(COMMENT);
     }
 

--- a/src/test/java/com/philips/research/spdxbuilder/core/domain/PackageTest.java
+++ b/src/test/java/com/philips/research/spdxbuilder/core/domain/PackageTest.java
@@ -7,7 +7,6 @@ package com.philips.research.spdxbuilder.core.domain;
 
 import com.github.packageurl.PackageURL;
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,6 +29,8 @@ class PackageTest {
         assertThat(pkg.isInternal()).isFalse();
         assertThat(pkg.getPurl()).isEmpty();
         assertThat(pkg.getConcludedLicense()).isEmpty();
+        assertThat(pkg.getDeclaredLicense()).isEmpty();
+        assertThat(pkg.getDetectedLicenses()).isEmpty();
     }
 
     @Test
@@ -67,44 +68,19 @@ class PackageTest {
     }
 
     @Test
+    void addsDetectedLicenses() {
+        pkg.addDetectedLicense(LICENSE);
+        pkg.addDetectedLicense(LICENSE);
+        pkg.addDetectedLicense(License.of("Something custom"));
+        pkg.addDetectedLicense(License.NONE);
+
+        assertThat(pkg.getDetectedLicenses()).hasSize(2);
+    }
+
+    @Test
     void implementsEquals() {
         EqualsVerifier.forClass(Package.class)
                 .withOnlyTheseFields("namespace", "name", "version")
                 .verify();
-    }
-
-    @Nested
-    class Licenses {
-        @Test
-        void licensesAreOptional() {
-            assertThat(pkg.getDetectedLicense()).isEmpty();
-            assertThat(pkg.getDeclaredLicense()).isEmpty();
-            assertThat(pkg.getConcludedLicense()).isEmpty();
-        }
-
-        @Test
-        void concludedLicenseDefaultsToDeclaredLicense() {
-            pkg.setDeclaredLicense(LICENSE);
-
-            assertThat(pkg.getDeclaredLicense()).contains(LICENSE);
-            assertThat(pkg.getConcludedLicense()).contains(LICENSE);
-        }
-
-        @Test
-        void concludedLicenseDefaultsToConcluded_noDeclaredLicense() {
-            pkg.setDetectedLicense(LICENSE);
-
-            assertThat(pkg.getDetectedLicense()).contains(LICENSE);
-            assertThat(pkg.getDeclaredLicense()).isEmpty();
-            assertThat(pkg.getConcludedLicense()).contains(LICENSE);
-        }
-
-        @Test
-        void concludedLicenseOverridesDeclaredLicense() {
-            pkg.setDeclaredLicense(License.of("Other"));
-            pkg.setConcludedLicense(LICENSE);
-
-            assertThat(pkg.getConcludedLicense()).contains(LICENSE);
-        }
     }
 }

--- a/src/test/java/com/philips/research/spdxbuilder/persistence/bom_base/BomBaseApiTest.java
+++ b/src/test/java/com/philips/research/spdxbuilder/persistence/bom_base/BomBaseApiTest.java
@@ -31,7 +31,10 @@ class BomBaseApiTest {
         private static final String SHA256 = "sha256";
         private static final String SOURCE_LOCATION = "source_location";
         private static final String DECLARED_LICENSE = "declared_license";
-        private static final String DETECTED_LICENSE = "detected_license";
+        private static final String DETECTED_LICENSES = "detected_licenses";
+        private static final String DETECTED_LICENSE1 = "license1";
+        private static final String DETECTED_LICENSE2 = "license2";
+
         final PackageJson meta = new PackageJson();
 
         @Test
@@ -47,7 +50,7 @@ class BomBaseApiTest {
             meta.attributes.put(SHA256, SHA256);
             meta.attributes.put(SOURCE_LOCATION, SOURCE_URI);
             meta.attributes.put(DECLARED_LICENSE, DECLARED_LICENSE);
-            meta.attributes.put(DETECTED_LICENSE, DETECTED_LICENSE);
+            meta.attributes.put(DETECTED_LICENSES, DETECTED_LICENSE1 + '\n' + DETECTED_LICENSE2);
 
             assertThat(meta.getTitle()).contains(TITLE);
             assertThat(meta.getDescription()).contains(DESCRIPTION);
@@ -60,7 +63,7 @@ class BomBaseApiTest {
             assertThat(meta.getSha256()).contains(SHA256);
             assertThat(meta.getSourceLocation()).contains(URI.create(SOURCE_URI));
             assertThat(meta.getDeclaredLicense()).contains(DECLARED_LICENSE);
-            assertThat(meta.getDetectedLicense()).contains(DETECTED_LICENSE);
+            assertThat(meta.getDetectedLicenses()).containsExactly(DETECTED_LICENSE1, DETECTED_LICENSE2);
         }
 
         @Test

--- a/src/test/java/com/philips/research/spdxbuilder/persistence/bom_base/BomBaseKnowledgeBaseTest.java
+++ b/src/test/java/com/philips/research/spdxbuilder/persistence/bom_base/BomBaseKnowledgeBaseTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.net.URL;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -74,7 +75,7 @@ class BomBaseKnowledgeBaseTest {
 //        when(meta.getOriginator()).thenReturn(Optional.of(ORIGINATOR));
         when(meta.getSourceLocation()).thenReturn(Optional.of(URI.create(SOURCE_LOCATION)));
         when(meta.getDeclaredLicense()).thenReturn(Optional.of(DECLARED_LICENSE));
-        when(meta.getDetectedLicense()).thenReturn(Optional.of(DETECTED_LICENSE));
+        when(meta.getDetectedLicenses()).thenReturn(List.of(DETECTED_LICENSE));
 
         final var success = knowledgeBase.enhance(bom);
 
@@ -90,7 +91,7 @@ class BomBaseKnowledgeBaseTest {
 //        assertThat(pkg.getSupplier()).contains();
         assertThat(pkg.getSourceLocation()).contains(URI.create(SOURCE_LOCATION));
         assertThat(pkg.getDeclaredLicense()).contains(LicenseParser.parse(DECLARED_LICENSE));
-        assertThat(pkg.getDetectedLicense()).contains(LicenseParser.parse(DETECTED_LICENSE));
+        assertThat(pkg.getDetectedLicenses()).contains(LicenseParser.parse(DETECTED_LICENSE));
     }
 
     @Test

--- a/src/test/java/com/philips/research/spdxbuilder/persistence/license_scanner/LicenseKnowledgeBaseTest.java
+++ b/src/test/java/com/philips/research/spdxbuilder/persistence/license_scanner/LicenseKnowledgeBaseTest.java
@@ -44,7 +44,7 @@ class LicenseKnowledgeBaseTest {
 
         knowledgeBase.enhance(bom);
 
-        assertThat(pkg.getDetectedLicense()).contains(LICENSE);
+        assertThat(pkg.getDetectedLicenses()).contains(LICENSE);
         verify(client, never()).contest(any(), any());
     }
 
@@ -56,7 +56,7 @@ class LicenseKnowledgeBaseTest {
 
         knowledgeBase.enhance(bom);
 
-        assertThat(pkg.getConcludedLicense()).contains(LICENSE);
+        assertThat(pkg.getConcludedLicense()).isEmpty();
         verify(client).contest(PURL, LICENSE.toString());
     }
 

--- a/src/test/java/com/philips/research/spdxbuilder/persistence/tree/TreeReaderTest.java
+++ b/src/test/java/com/philips/research/spdxbuilder/persistence/tree/TreeReaderTest.java
@@ -57,13 +57,37 @@ class TreeReaderTest {
                 new Relation(pkg1, pkg2, Relation.Type.DYNAMIC_LINK));
     }
 
-    @Test
-    void passesInternalGlobPatterns() {
-        final var stream = stream("ns/internal@1");
+    class InternalPackages {
+        @Test
+        void defaultsToReleaseOutput() {
+            final var stream = stream("ns/main@1");
 
-        new TreeReader(stream, "npm", null, List.of("*/int*")).read(bom);
+            new TreeReader(stream, "npm", null, List.of()).read(bom);
 
-        assertThat(bom.getPackages().get(0).isInternal()).isTrue();
+            assertThat(bom.getPackages().get(0).isInternal()).isFalse();
+        }
+
+        @Test
+        void flagsProductReleaseOutput() {
+            final var stream = stream("ns/main@1");
+
+            new TreeReader(stream, "npm", null, List.of())
+                    .setRelease(true)
+                    .read(bom);
+
+            assertThat(bom.getPackages().get(0).isInternal()).isTrue();
+        }
+
+        @Test
+        void passesInternalGlobPatterns() {
+            final var stream = stream("ns/internal@1");
+
+            new TreeReader(stream, "npm", null, List.of("*/int*"))
+                    .setRelease(true)
+                    .read(bom);
+
+            assertThat(bom.getPackages().get(0).isInternal()).isTrue();
+        }
     }
 
     @Test


### PR DESCRIPTION
(This is all about parsing an SPDX from a packages tree.)

- Root packages are now treated by default as "internal" (to indicate the temporary nature of this SPDX).
- The `--release` option can override this default behaviour.
- "Internal" packages do not expose a package URL in the SPDX to indicate they are not (yet) released nor shared by other products.
- Added documentation about the configuration file and internal packages.
- Declared licenses are no longer automatically copied as "concluded" licenses. (This is better in line with the SPDX specification.)
- Detected licenses reported by BOM-Base are no longer automatically joined, but treated as a list and output as individual statements in the SPDX output. (This is in line with the fine print of the SPDX specification.)