### PR TITLE
Feature: Recurse subprojects in BD export

### DIFF
--- a/src/main/java/com/philips/research/spdxbuilder/core/domain/Package.java
+++ b/src/main/java/com/philips/research/spdxbuilder/core/domain/Package.java
@@ -220,6 +220,6 @@ public final class Package {
         return getPurl()
                 .filter(p -> !isInternal())
                 .map(PackageURL::canonicalize)
-                .orElse(getFullName() + (version.isBlank() ? "" : " version " + version));
+                .orElse(getFullName() + (version.isBlank() ? "" : ", version " + version));
     }
 }

--- a/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckApi.java
+++ b/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckApi.java
@@ -47,6 +47,10 @@ public interface BlackDuckApi {
     Call<ItemsJson<ProjectVersionJson>> findProjectVersions(@Path("projectId") UUID projectId, @Query("q") String filter);
 
     @Headers(BILL_OF_MATERIALS_6_JSON)
+    @GET("/api/projects/{projectId}/versions/{versionId}/components?limit=9999")
+    Call<ItemsJson<ComponentVersionJson>> getBomComponents(@Path("projectId") UUID projectId, @Path("versionId") UUID versionId);
+
+    @Headers(BILL_OF_MATERIALS_6_JSON)
     @GET("/api/projects/{projectId}/versions/{versionId}/hierarchical-components?limit=9999")
     Call<ItemsJson<ComponentVersionJson>> getRootComponentVersions(@Path("projectId") UUID projectId, @Path("versionId") UUID versionId);
 
@@ -138,6 +142,7 @@ public interface BlackDuckApi {
     }
 
     class LinksJson {
+        URI href;
         List<LinkJson> links = new ArrayList<>();
     }
 
@@ -146,6 +151,7 @@ public interface BlackDuckApi {
         String componentName;
         String componentVersionName;
         URI componentVersion;
+        String componentType;
 
         List<String> usages = new ArrayList<>();
         List<OriginJson> origins = new ArrayList<>();
@@ -196,6 +202,11 @@ public interface BlackDuckApi {
                     .findAny()
                     .map(link -> UriHelper.longFromUri(link.href, 1))
                     .orElse(0L);
+        }
+
+        @Override
+        public boolean isSubproject() {
+            return "SUB_PROJECT".equals(componentType);
         }
 
         @Override

--- a/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckComponent.java
+++ b/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckComponent.java
@@ -27,4 +27,6 @@ interface BlackDuckComponent {
     License getLicense();
 
     long getHierarchicalId();
+
+    boolean isSubproject();
 }

--- a/src/main/java/com/philips/research/spdxbuilder/persistence/spdx/SpdxWriter.java
+++ b/src/main/java/com/philips/research/spdxbuilder/persistence/spdx/SpdxWriter.java
@@ -6,8 +6,10 @@
 package com.philips.research.spdxbuilder.persistence.spdx;
 
 import com.philips.research.spdxbuilder.core.BomWriter;
+import com.philips.research.spdxbuilder.core.domain.BillOfMaterials;
+import com.philips.research.spdxbuilder.core.domain.LicenseDictionary;
 import com.philips.research.spdxbuilder.core.domain.Package;
-import com.philips.research.spdxbuilder.core.domain.*;
+import com.philips.research.spdxbuilder.core.domain.Relation;
 
 import java.io.File;
 import java.io.FileOutputStream;


### PR DESCRIPTION
Recurses Black Duck sub-projects to create one integrated BOM.

Subprojects are like regular components in the normal, but they are not listed in the hierarchical BOM API. Therefore an additional query of "all components" of the project is necessary to filter the sub-project components.