### PR TITLE
Feature/fix bd export

### DIFF
--- a/src/main/java/com/philips/research/spdxbuilder/core/domain/LicenseParser.java
+++ b/src/main/java/com/philips/research/spdxbuilder/core/domain/LicenseParser.java
@@ -82,8 +82,8 @@ public class LicenseParser {
 
     private void addToken() {
         final var token = buffer.toString().trim();
-        switch (token.toLowerCase()) {
-            case "with":
+        switch (token) {
+            case "WITH":
                 if (current.equals(License.NONE) && !identifier.isBlank() && !parsingWith) {
                     current = dictionary.licenseFor(identifier);
                     identifier = "";
@@ -92,11 +92,11 @@ public class LicenseParser {
                     identifier += ' ' + token;
                 }
                 break;
-            case "and":
+            case "AND":
                 appendCurrent();
                 mode = Mode.AND;
                 break;
-            case "or":
+            case "OR":
                 appendCurrent();
                 mode = Mode.OR;
                 break;

--- a/src/main/java/com/philips/research/spdxbuilder/core/domain/Package.java
+++ b/src/main/java/com/philips/research/spdxbuilder/core/domain/Package.java
@@ -220,6 +220,6 @@ public final class Package {
         return getPurl()
                 .filter(p -> !isInternal())
                 .map(PackageURL::canonicalize)
-                .orElse(getFullName() + (version.isBlank() ? "" : ", version " + version));
+                .orElse(getFullName() + (version == null || version.isBlank() ? "" : ", version " + version));
     }
 }

--- a/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckApi.java
+++ b/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckApi.java
@@ -87,10 +87,10 @@ public interface BlackDuckApi {
         URI href;
     }
 
-    @SuppressWarnings("NotNullFieldNotInitialized")
     class ProjectJson implements BlackDuckProduct {
-        String name;
+        String name = "";
         @NullOr String description;
+        @SuppressWarnings("NotNullFieldNotInitialized")
         LinkJson _meta;
 
         @Override
@@ -114,11 +114,11 @@ public interface BlackDuckApi {
         }
     }
 
-    @SuppressWarnings("NotNullFieldNotInitialized")
     class ProjectVersionJson implements BlackDuckProduct {
-        String versionName;
+        String versionName = "";
         @NullOr String releaseComments;
         @NullOr LicenseJson license;
+        @SuppressWarnings("NotNullFieldNotInitialized")
         LinkJson _meta;
 
         @Override
@@ -143,6 +143,7 @@ public interface BlackDuckApi {
     }
 
     class LinksJson {
+        @SuppressWarnings("NotNullFieldNotInitialized")
         URI href;
         List<LinkJson> links = new ArrayList<>();
     }

--- a/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/PackageIdentifier.java
+++ b/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/PackageIdentifier.java
@@ -63,10 +63,11 @@ public class PackageIdentifier {
     private @NullOr String namespace() {
         switch (externalNamespace) {
             case "maven":
+                return fromEnd(':', 2);
             case "github":
             case "gitlab":
             case "bitbucket":
-                return fromEnd(':', 2);
+                return fromEnd('/', 1);
             case "centos":
             case "fedora":
             case "opensuse":
@@ -84,10 +85,15 @@ public class PackageIdentifier {
     private @NullOr String name() {
         switch (externalNamespace) {
             case "maven":
+                return fromEnd(':', 1);
             case "github":
             case "gitlab":
             case "bitbucket":
-                return fromEnd(':', 1);
+                @SuppressWarnings("ConstantConditions")
+                final var name = fromStart(':', 0);
+                @SuppressWarnings("ConstantConditions")
+                final var pos = name.indexOf('/');
+                return  (pos < 0) ? name : name.substring(pos+1);
             case "alpine":
             case "arch_linux":
             case "centos":
@@ -104,10 +110,11 @@ public class PackageIdentifier {
     private @NullOr String version() {
         switch (externalNamespace) {
             case "maven":
+                return fromStart(':', 2);
             case "github":
             case "gitlab":
             case "bitbucket":
-                return fromStart(':', 2);
+                return fromStart(':', 1);
             case "alpine":
             case "arch_linux":
             case "centos":

--- a/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/PackageIdentifier.java
+++ b/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/PackageIdentifier.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2020-2021, Koninklijke Philips N.V., https://www.philips.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.philips.research.spdxbuilder.persistence.blackduck;
+
+import com.github.packageurl.MalformedPackageURLException;
+import com.github.packageurl.PackageURL;
+import com.github.packageurl.PackageURLBuilder;
+import pl.tlinkowski.annotation.basic.NullOr;
+
+import java.util.Optional;
+
+public class PackageIdentifier {
+    String externalNamespace;
+    String externalId;
+
+    PackageIdentifier(String namespace, String id) {
+        this.externalNamespace = namespace;
+        this.externalId = id;
+    }
+
+    Optional<PackageURL> getPurl() {
+        try {
+            return Optional.of(PackageURLBuilder.aPackageURL()
+                    .withType(type())
+                    .withNamespace(namespace())
+                    .withName(name())
+                    .withVersion(version())
+                    .build());
+        } catch (MalformedPackageURLException e) {
+            System.err.println("Invalid package URL for namespace '" + externalNamespace + "', id '" + externalId + "': " + e);
+            return Optional.empty();
+        }
+    }
+
+    private String type() {
+        switch (externalNamespace) {
+            case "arch_linux":
+                return "arch";
+            case "centos":
+            case "fedora":
+            case "redhat":
+            case "opensuse":
+                return "rpm";
+            case "crates":
+                return "cargo";
+            case "dart":
+                return "pub";
+            case "debian":
+            case "ubuntu":
+                return "deb";
+            case "npmjs":
+                return "npm";
+            case "rubygems":
+                return "gem";
+            default:
+                return externalNamespace;
+        }
+    }
+
+    private @NullOr String namespace() {
+        switch (externalNamespace) {
+            case "maven":
+            case "github":
+            case "gitlab":
+            case "bitbucket":
+                return fromEnd(':', 2);
+            case "centos":
+            case "fedora":
+            case "opensuse":
+            case "ubuntu":
+                return externalNamespace;
+            case "alpine":
+            case "arch_linux":
+            case "debian":
+                return null;
+            default:
+                return fromEnd('/', 2);
+        }
+    }
+
+    private @NullOr String name() {
+        switch (externalNamespace) {
+            case "maven":
+            case "github":
+            case "gitlab":
+            case "bitbucket":
+                return fromEnd(':', 1);
+            case "alpine":
+            case "arch_linux":
+            case "centos":
+            case "debian":
+            case "fedora":
+            case "opensuse":
+            case "ubuntu":
+                return fromEnd('/', 2);
+            default:
+                return fromEnd('/', 1);
+        }
+    }
+
+    private @NullOr String version() {
+        switch (externalNamespace) {
+            case "maven":
+            case "github":
+            case "gitlab":
+            case "bitbucket":
+                return fromStart(':', 2);
+            case "alpine":
+            case "arch_linux":
+            case "centos":
+            case "debian":
+            case "fedora":
+            case "opensuse":
+            case "ubuntu":
+                return fromEnd('/', 1);
+            default:
+                return fromEnd('/', 0);
+        }
+    }
+
+    private @NullOr String fromStart(char sep, int offset) {
+        final var parts = externalId.split(String.valueOf(sep));
+        return (offset < parts.length) ? parts[offset] : null;
+    }
+
+    private @NullOr String fromEnd(char sep, int offset) {
+        final var parts = externalId.split(String.valueOf(sep));
+        return (offset < parts.length) ? parts[parts.length - offset - 1] : null;
+    }
+}

--- a/src/test/java/com/philips/research/spdxbuilder/core/domain/LicenseParserTest.java
+++ b/src/test/java/com/philips/research/spdxbuilder/core/domain/LicenseParserTest.java
@@ -40,7 +40,7 @@ class LicenseParserTest {
 
     @Test
     void withExceptionClause() {
-        var license = LicenseParser.parse(IDENTIFIER + " with " + EXCEPTION);
+        var license = LicenseParser.parse(IDENTIFIER + " WITH " + EXCEPTION);
 
         assertThat(license).isEqualTo(License.of(IDENTIFIER).with(EXCEPTION));
     }
@@ -68,15 +68,15 @@ class LicenseParserTest {
 
     @Test
     void ignoresRogueWithClause() {
-        final var license = LicenseParser.parse("with " + EXCEPTION);
+        final var license = LicenseParser.parse("WITH " + EXCEPTION);
 
         assertThat(license.toString()).contains("Ref");
-        assertThat(dictionary.getCustomLicenses()).containsValue("with " + EXCEPTION);
+        assertThat(dictionary.getCustomLicenses()).containsValue("WITH " + EXCEPTION);
     }
 
     @Test
     void throws_doubleWithClause() {
-        final var text = IDENTIFIER + " WITH " + EXCEPTION + " with " + EXCEPTION;
+        final var text = IDENTIFIER + " WITH " + EXCEPTION + " WITH " + EXCEPTION;
         final var license = LicenseParser.parse(text);
 
         assertThat(license.toString()).contains("Ref");
@@ -85,21 +85,21 @@ class LicenseParserTest {
 
     @Test
     void parsesOrCombination() {
-        var license = LicenseParser.parse(IDENTIFIER + " or " + IDENTIFIER2 + " or " + IDENTIFIER3);
+        var license = LicenseParser.parse(IDENTIFIER + " OR " + IDENTIFIER2);
 
-        assertThat(license).isEqualTo(License.of(IDENTIFIER).or(License.of(IDENTIFIER2)).or(License.of(IDENTIFIER3)));
+        assertThat(license).isEqualTo(License.of(IDENTIFIER).or(License.of(IDENTIFIER2)));
     }
 
     @Test
     void parsesAndCombination() {
-        var license = LicenseParser.parse(IDENTIFIER + " and " + IDENTIFIER2 + " and " + IDENTIFIER3);
+        var license = LicenseParser.parse(IDENTIFIER + " AND " + IDENTIFIER2);
 
-        assertThat(license).isEqualTo(License.of(IDENTIFIER).and(License.of(IDENTIFIER2)).and(License.of(IDENTIFIER3)));
+        assertThat(license).isEqualTo(License.of(IDENTIFIER).and(License.of(IDENTIFIER2)));
     }
 
     @Test
     void parsesMixedLogicCombination() {
-        var license = LicenseParser.parse(IDENTIFIER + " or " + IDENTIFIER2 + " and " + IDENTIFIER3);
+        var license = LicenseParser.parse(IDENTIFIER + " OR " + IDENTIFIER2 + " AND " + IDENTIFIER3);
 
         assertThat(license).isEqualTo(License.of(IDENTIFIER).or(License.of(IDENTIFIER2)).and(License.of(IDENTIFIER3)));
     }
@@ -114,28 +114,28 @@ class LicenseParserTest {
 
     @Test
     void addsWithClauseToLatestParsedLicense() {
-        var license = LicenseParser.parse(IDENTIFIER + " or " + IDENTIFIER2 + " with " + EXCEPTION + " and " + IDENTIFIER3);
+        var license = LicenseParser.parse(IDENTIFIER + " OR " + IDENTIFIER2 + " WITH " + EXCEPTION + " AND " + IDENTIFIER3);
 
         assertThat(license).isEqualTo(License.of(IDENTIFIER).or(License.of(IDENTIFIER2).with(EXCEPTION)).and(License.of(IDENTIFIER3)));
     }
 
     @Test
     void parsesBracketedCombination() {
-        var license = LicenseParser.parse(IDENTIFIER + " or (" + IDENTIFIER2 + " and " + IDENTIFIER3 + ")");
+        var license = LicenseParser.parse(IDENTIFIER + " OR (" + IDENTIFIER2 + " AND " + IDENTIFIER3 + ")");
 
         assertThat(license).isEqualTo(License.of(IDENTIFIER).or(License.of(IDENTIFIER2).and(License.of(IDENTIFIER3))));
     }
 
     @Test
     void parsesNestedBrackets() {
-        var license = LicenseParser.parse("((" + IDENTIFIER + ") or (" + IDENTIFIER2 + "))");
+        var license = LicenseParser.parse("((" + IDENTIFIER + ") OR (" + IDENTIFIER2 + "))");
 
         assertThat(license).isEqualTo(License.of(IDENTIFIER).or(License.of(IDENTIFIER2)));
     }
 
     @Test
     void withClauseFollowedByOpeningBracketIsAndRelationWithoutException() {
-        final var license = LicenseParser.parse(IDENTIFIER + " with (" + EXCEPTION + ")");
+        final var license = LicenseParser.parse(IDENTIFIER + " WITH (" + EXCEPTION + ")");
 
         assertThat(license.toString()).contains(IDENTIFIER).contains("Ref");
         assertThat(dictionary.getCustomLicenses()).hasSize(1).containsValue(EXCEPTION);

--- a/src/test/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckApiTest.java
+++ b/src/test/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckApiTest.java
@@ -5,7 +5,6 @@
 
 package com.philips.research.spdxbuilder.persistence.blackduck;
 
-import com.github.packageurl.PackageURL;
 import com.philips.research.spdxbuilder.core.domain.License;
 import com.philips.research.spdxbuilder.persistence.blackduck.BlackDuckApi.ComponentVersionJson;
 import com.philips.research.spdxbuilder.persistence.blackduck.BlackDuckApi.LicenseJson;
@@ -73,25 +72,6 @@ class BlackDuckApiTest {
             final var license = component.getLicense();
 
             assertThat(license).isEqualTo(License.of(LICENSE).or(License.of(LICENSE2)));
-        }
-    }
-
-    @Nested
-    class PackageUrlConversion {
-        @Test
-        void convertsOriginToPackageURL() throws Exception {
-            assertPurl("maven", "Group:Name:Version", new PackageURL("pkg:maven/Group/Name@Version"));
-            assertPurl("maven", "::Name:Version", new PackageURL("pkg:maven/Name@Version"));
-            assertPurl("maven", "Name:Version", new PackageURL("pkg:maven/Name@Version"));
-            assertPurl("UNKNOWN", "Name/Version", new PackageURL("pkg:generic/Name@Version"));
-            assertPurl("npmjs", "Name/Version", new PackageURL("pkg:npm/Name@Version"));
-        }
-
-        private void assertPurl(String externalNamespace, String externalId, PackageURL purl) {
-            final var origin = new BlackDuckApi.OriginJson();
-            origin.externalNamespace = externalNamespace;
-            origin.externalId = externalId;
-            assertThat(origin.getPurl()).isEqualTo(purl);
         }
     }
 }

--- a/src/test/java/com/philips/research/spdxbuilder/persistence/blackduck/PackageIdentifierTest.java
+++ b/src/test/java/com/philips/research/spdxbuilder/persistence/blackduck/PackageIdentifierTest.java
@@ -23,7 +23,8 @@ class PackageIdentifierTest {
         // apache_software
         assertIdentifier("arch_linux", "name/version/architecture", "arch/name@version");
         // automotive_linux
-        assertIdentifier("bitbucket", "org:name:version", "bitbucket/org/name@version");
+        assertIdentifier("bitbucket", "org/name:version", "bitbucket/org/name@version");
+        assertIdentifier("bitbucket", "org/name", "bitbucket/org/name");
         assertIdentifier("bower", "name/version", "bower/name@version");
         assertIdentifier("bower", "@scope/name/version", "bower/%40scope/name@version");
         assertIdentifier("centos", "name/version/architecture", "rpm/centos/name@version");
@@ -43,9 +44,11 @@ class PackageIdentifierTest {
         assertIdentifier("fedora", "name/version/architecture", "rpm/fedora/name@version");
         // freedesktop_org
         // gitcafe
-        assertIdentifier("github", "org:name:version", "github/org/name@version");
+        assertIdentifier("github", "org/name:version", "github/org/name@version");
+        assertIdentifier("github", "org/name", "github/org/name");
         // github_gist
-        assertIdentifier("gitlab", "org:name:version", "gitlab/org/name@version");
+        assertIdentifier("gitlab", "org/name:version", "gitlab/org/name@version");
+        assertIdentifier("gitlab", "org/name", "gitlab/org/name");
         // gitorious
         // gnu
         assertIdentifier("golang", "name/version", "golang/name@version");

--- a/src/test/java/com/philips/research/spdxbuilder/persistence/blackduck/PackageIdentifierTest.java
+++ b/src/test/java/com/philips/research/spdxbuilder/persistence/blackduck/PackageIdentifierTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2020-2021, Koninklijke Philips N.V., https://www.philips.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.philips.research.spdxbuilder.persistence.blackduck;
+
+import com.github.packageurl.MalformedPackageURLException;
+import com.github.packageurl.PackageURL;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PackageIdentifierTest {
+    @Test
+        // (Formats are based on external namespaces list provided by Black Duck.)
+    void decodesFormats() {
+        assertIdentifier("alpine", "name/version/architecture", "alpine/name@version");
+        // alt_linux
+        // anaconda
+        // android
+        // android_sdk
+        // apache_software
+        assertIdentifier("arch_linux", "name/version/architecture", "arch/name@version");
+        // automotive_linux
+        assertIdentifier("bitbucket", "org:name:version", "bitbucket/org/name@version");
+        assertIdentifier("bower", "name/version", "bower/name@version");
+        assertIdentifier("bower", "@scope/name/version", "bower/%40scope/name@version");
+        assertIdentifier("centos", "name/version/architecture", "rpm/centos/name@version");
+        // clearlinux
+        assertIdentifier("cocoapods", "name/version", "cocoapods/name@version");
+        // codeplex
+        // codeplex_group
+        assertIdentifier("conan", "name/version", "conan/name@version");
+        assertIdentifier("cpan", "name/version", "cpan/name@version");
+        // cpe
+        assertIdentifier("cran", "name/version", "cran/name@version");
+        assertIdentifier("crates", "name/version", "cargo/name@version");
+        assertIdentifier("dart", "name/version", "pub/name@version");
+        assertIdentifier("debian", "name/version/architecture", "deb/name@version");
+        // eclipse
+        // efisbot
+        assertIdentifier("fedora", "name/version/architecture", "rpm/fedora/name@version");
+        // freedesktop_org
+        // gitcafe
+        assertIdentifier("github", "org:name:version", "github/org/name@version");
+        // github_gist
+        assertIdentifier("gitlab", "org:name:version", "gitlab/org/name@version");
+        // gitorious
+        // gnu
+        assertIdentifier("golang", "name/version", "golang/name@version");
+        assertIdentifier("golang", "domain/name/version", "golang/domain/name@version");
+        // googlecode
+        // hackage
+        assertIdentifier("hex", "name/version", "hex/name@version");
+        assertIdentifier("hex", "namespace/name/version", "hex/namespace/name@version");
+        // java_net
+        // kb_classic
+        // launchpad
+        // long_tail
+        assertIdentifier("maven", "group:name:version", "maven/group/name@version");
+        // mongo_db
+        assertIdentifier("npmjs", "name/version", "npm/name@version");
+        assertIdentifier("npmjs", "@scope/name/version", "npm/%40scope/name@version");
+        assertIdentifier("nuget", "name/version", "nuget/name@version");
+        // openembedded
+        // openjdk
+        assertIdentifier("opensuse", "name/version/architecture", "rpm/opensuse/name@version");
+        // oracle_linux
+        // packagist
+        // pear
+        // photon
+        // protocode_sc
+        assertIdentifier("pypi", "name/version", "pypi/name@version");
+        // raspberry_pi
+        assertIdentifier("redhat", "dist/name/version", "rpm/dist/name@version");
+        assertIdentifier("redhat", "name/version", "rpm/name@version");
+        // ros
+        // rubyforge
+        assertIdentifier("rubygems", "name/version", "gem/name@version");
+        // runtime
+        // sourceforge
+        // sourceforge_ip
+        // tianocore
+        assertIdentifier("ubuntu", "name/version/architecture", "deb/ubuntu/name@version");
+        // yokto
+    }
+
+    private void assertIdentifier(String namespace, String identifier, String expected) {
+        try {
+            final var id = new PackageIdentifier(namespace, identifier);
+            assertThat(id.getPurl()).contains(new PackageURL("pkg:" + expected));
+        } catch (MalformedPackageURLException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}


### PR DESCRIPTION
- Highly improved decoding of package URLs from internal Black Duck identifiers.
- Licenses are now only split on upper case AND and OR.