### PR TITLE
Feature: Matches licenses also by full name

### DIFF
--- a/src/main/java/com/philips/research/spdxbuilder/core/domain/LicenseDictionary.java
+++ b/src/main/java/com/philips/research/spdxbuilder/core/domain/LicenseDictionary.java
@@ -96,7 +96,10 @@ public class LicenseDictionary {
             final var json = MAPPER.readValue(LICENSES, LicensesJson.class);
             json.licenses.stream()
                     .filter(lic -> !lic.isDeprecatedLicenseId)
-                    .forEach(lic -> spdxIdentifiers.put(lic.licenseId.toLowerCase(), lic.licenseId));
+                    .forEach(lic -> {
+                        spdxIdentifiers.put(lic.licenseId.toLowerCase(), lic.licenseId);
+                        spdxIdentifiers.put(lic.name.toLowerCase(), lic.licenseId);
+                    });
             return json.licenseListVersion;
         } catch (Exception e) {
             throw new RuntimeException("Failed to read SPDX licenses from " + LICENSES, e);
@@ -108,7 +111,10 @@ public class LicenseDictionary {
             final var json = MAPPER.readValue(EXCEPTIONS, LicensesJson.class);
             json.exceptions.stream()
                     .filter(lic -> !lic.isDeprecatedLicenseId)
-                    .forEach(lic -> spdxExceptions.put(lic.licenseExceptionId.toLowerCase(), lic.licenseExceptionId));
+                    .forEach(lic -> {
+                        spdxExceptions.put(lic.licenseExceptionId.toLowerCase(), lic.licenseExceptionId);
+                        spdxExceptions.put(lic.name.toLowerCase(), lic.licenseExceptionId);
+                    });
         } catch (Exception e) {
             throw new RuntimeException("Failed to read SPDX exceptions from " + EXCEPTIONS, e);
         }
@@ -188,5 +194,6 @@ public class LicenseDictionary {
         boolean isDeprecatedLicenseId;
         String licenseId;
         String licenseExceptionId;
+        String name;
     }
 }

--- a/src/test/java/com/philips/research/spdxbuilder/core/domain/LicenseDictionaryTest.java
+++ b/src/test/java/com/philips/research/spdxbuilder/core/domain/LicenseDictionaryTest.java
@@ -46,6 +46,13 @@ class LicenseDictionaryTest {
     }
 
     @Test
+    void detectsSpdxLicensesByName() {
+        final var license = dictionary.licenseFor("MIT License");
+
+        assertThat(license).isEqualTo(License.of("MIT"));
+    }
+
+    @Test
     void createsCustomLicenseIdentifier() {
         final var custom1 = dictionary.licenseFor("First");
         final var custom2 = dictionary.licenseFor("Second");
@@ -101,7 +108,16 @@ class LicenseDictionaryTest {
 
         final var license = dictionary.withException(base, " Classpath-exception-2.0 ");
 
-        assertThat(license).isEqualTo(License.of("GPL-3.0-only").with("Classpath-exception-2.0"));
+        assertThat(license).isEqualTo(base.with("Classpath-exception-2.0"));
+    }
+
+    @Test
+    void detectsSpdxExceptionsByName() {
+        final var base = License.of("GPL-3.0-only");
+
+        final var license = dictionary.withException(base, "Classpath exception 2.0");
+
+        assertThat(license).isEqualTo(base.with("Classpath-exception-2.0"));
     }
 
     @Test


### PR DESCRIPTION
If the input provides a full (official) license name instead of an SPDX
identifier, the matching SPDX identifier is automatically substituted. This
also works for WITH exceptions.