### PR TITLE
Fix: Include manually added components from Black Duck

### DIFF
--- a/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckApi.java
+++ b/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckApi.java
@@ -156,6 +156,7 @@ public interface BlackDuckApi {
         String componentType;
 
         List<String> usages = new ArrayList<>();
+        List<String> matchTypes = new ArrayList<>();
         List<OriginJson> origins = new ArrayList<>();
         List<LicenseJson> licenses = new ArrayList<>();
         LinksJson _meta;
@@ -214,6 +215,11 @@ public interface BlackDuckApi {
         }
 
         @Override
+        public boolean isAdditionalComponent() {
+            return isSubproject() || matchTypes.contains("MANUAL_BOM_COMPONENT");
+        }
+
+        @Override
         public String toString() {
             return componentName + ' ' + componentVersionName;
         }
@@ -223,6 +229,14 @@ public interface BlackDuckApi {
         OriginJson() {
             //noinspection ConstantConditions
             super(null, null);
+        }
+
+        @Override
+        Optional<PackageURL> getPurl() {
+            if ("unknown".equals(externalNamespace)) {
+                return Optional.empty();
+            }
+            return super.getPurl();
         }
     }
 

--- a/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckClient.java
+++ b/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckClient.java
@@ -123,7 +123,7 @@ public class BlackDuckClient {
         final var subprojects = query(api.getBomComponents(projectId, versionId))
                 .map(object -> (List<BlackDuckComponent>) (List<? extends BlackDuckComponent>) object.items)
                 .orElse(List.of()).stream()
-                .filter(BlackDuckComponent::isSubproject)
+                .filter(BlackDuckComponent::isAdditionalComponent)
                 .collect(Collectors.toList());
         components.addAll(subprojects);
         return components;

--- a/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckComponent.java
+++ b/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckComponent.java
@@ -28,5 +28,7 @@ interface BlackDuckComponent {
 
     long getHierarchicalId();
 
+    boolean isAdditionalComponent();
+
     boolean isSubproject();
 }

--- a/src/test/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckApiTest.java
+++ b/src/test/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckApiTest.java
@@ -74,4 +74,24 @@ class BlackDuckApiTest {
             assertThat(license).isEqualTo(License.of(LICENSE).or(License.of(LICENSE2)));
         }
     }
+
+    @Nested
+    class Origin {
+        @Test
+        void defaultsToDecodingExternalId() {
+            final var json = new BlackDuckApi.OriginJson();
+            json.externalNamespace = "maven";
+            json.externalId = "group:name:version";
+
+            assertThat(json.getPurl()).isNotEmpty();
+        }
+
+        @Test
+        void noPackageUrl_unknownExternalId() {
+            final var json = new BlackDuckApi.OriginJson();
+            json.externalNamespace = "unknown";
+
+            assertThat(json.getPurl()).isEmpty();
+        }
+    }
 }

--- a/src/test/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckClientTest.java
+++ b/src/test/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckClientTest.java
@@ -284,7 +284,7 @@ class BlackDuckClientTest {
         }
 
         @Test
-        void readsSubprojectsAsComponents() {
+        void readsSubprojectsAndExtraComponents() {
             final var projectId = UUID.randomUUID();
             final var versionId = UUID.randomUUID();
             server.enqueue(EMPTY_LIST_RESPONSE);
@@ -294,14 +294,20 @@ class BlackDuckClientTest {
                                     .put("componentName", "Ignore me!")
                                     .put("componentType", "KB_COMPONENT"))
                             .put(new JSONObject()
+                                    .put("matchTypes", new JSONArray().put("MANUAL_BOM_COMPONENT"))
+                                    .put("componentVersion", "api/components/" + COMPONENT_ID + "/versions/" + COMPONENT_VERSION_ID + "/"))
+                            .put(new JSONObject()
                                     .put("componentType", "SUB_PROJECT")
                                     .put("componentVersion", "api/etc/components/" + projectId + "/versions/" + versionId)))
                     .toString()));
 
             final var components = client.getRootComponents(PROJECT_ID, VERSION_ID);
 
-            assertThat(components).hasSize(1);
-            final var subproject = components.get(0);
+            assertThat(components).hasSize(2);
+            final var extraComponent = components.get(0);
+            assertThat(extraComponent.getId()).isEqualTo(COMPONENT_ID);
+            assertThat(extraComponent.isAdditionalComponent()).isTrue();
+            final var subproject = components.get(1);
             assertThat(subproject.isSubproject()).isTrue();
             assertThat(subproject.getId()).isEqualTo(projectId);
             assertThat(subproject.getVersionId()).isEqualTo(versionId);


### PR DESCRIPTION
- Allow packages with an "unknown" external namespace (and no external id)