### PR TITLE
Feature/bd multi package conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,6 @@ A local ORT-based self-test (if ORT is installed locally) can be run by:
 
 Must-have:
 
-- [x] Properly expand Black Duck origin identifiers to package URLs.
-- [ ] Recursively import sub-projects from Black Duck.
 - [ ] Abort if ORT Analyzer raised errors.
 - [ ] Support the new (more compact) ORT tree structure. (Currently breaks Gradle projects.)
 - [ ] Add hashes of build results (where possible).

--- a/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckReader.java
+++ b/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckReader.java
@@ -136,9 +136,9 @@ public class BlackDuckReader implements BomReader {
             return;
         }
 
-        purls.stream()
-                .map(purl -> exportPackageIfNotExists(bom, component, purl, projectId, versionId))
-                .forEach(pkg -> exportRelation(bom, parent, pkg, relationshipFor(component)));
+        final var purl = purls.get(0);
+        final var pkg = exportPackageIfNotExists(bom, component, purl, projectId, versionId);
+        exportRelation(bom, parent, pkg, relationshipFor(component));
     }
 
     private Package exportPackageIfNotExists(BillOfMaterials bom, BlackDuckComponent component, PackageURL purl, UUID projectId, UUID versionId) {

--- a/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckReader.java
+++ b/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckReader.java
@@ -119,6 +119,9 @@ public class BlackDuckReader implements BomReader {
         if (purls.isEmpty()) {
             System.err.println("\nWARNING: Skipped component '" + component + "' as it does not specify any packages");
         }
+        if (purls.size() > 1) {
+            System.err.println("\nWARNING: Component '" + component + "' specifies " + purls.size() + " packages");
+        }
         purls.stream()
                 .map(purl -> exportPackageIfNotExists(bom, component, purl, projectId, versionId))
                 .forEach(pkg -> exportRelation(bom, parent, pkg, component));

--- a/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckReader.java
+++ b/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckReader.java
@@ -105,19 +105,25 @@ public class BlackDuckReader implements BomReader {
     }
 
     private void addSubproject(BillOfMaterials bom, Package parent, UUID projectId, UUID versionId, BlackDuckComponent component) {
-        final var pkg = new Package(null, component.getName(), component.getVersion())
-                .setConcludedLicense(component.getLicense());
-        bom.addPackage(pkg);
-        exportRelation(bom, parent, pkg, component);
+        final Package pkg = exportAnonymousPackage(bom, parent, component);
 
         final var components = client.getRootComponents(projectId, versionId);
         addChildren(bom, pkg, components, projectId, versionId);
     }
 
+    private Package exportAnonymousPackage(BillOfMaterials bom, Package parent, BlackDuckComponent component) {
+        final var pkg = new Package(null, component.getName(), component.getVersion())
+                .setConcludedLicense(component.getLicense());
+        bom.addPackage(pkg);
+        exportRelation(bom, parent, pkg, component);
+        return pkg;
+    }
+
     private void addChild(BillOfMaterials bom, Package parent, UUID projectId, UUID versionId, BlackDuckComponent component) {
         final var purls = component.getPackageUrls();
         if (purls.isEmpty()) {
-            System.err.println("\nWARNING: Skipped component '" + component + "' as it does not specify any packages");
+            System.err.println("\nWARNING: Component '" + component + "' does not specify any packages");
+            exportAnonymousPackage(bom, parent, component);
         }
         if (purls.size() > 1) {
             System.err.println("\nWARNING: Component '" + component + "' specifies " + purls.size() + " packages");

--- a/src/test/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckReaderTest.java
+++ b/src/test/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckReaderTest.java
@@ -181,12 +181,20 @@ class BlackDuckReaderTest {
         }
 
         @Test
-        void skipsComponentWithoutOrigin() {
+        void exportsComponentWithoutOriginAsAnonymous() {
             when(component.getPackageUrls()).thenReturn(List.of());
 
             reader.read(bom);
 
-            assertThat(bom.getPackages()).hasSize(1); // Only root
+            assertThat(bom.getPackages()).hasSize(2); // Root + anonymous
+            final var pkg = bom.getPackages().get(1);
+            assertThat(pkg.getName()).contains(NAME);
+            assertThat(pkg.getConcludedLicense()).contains(LICENSE);
+            assertThat(pkg.getPurl()).isEmpty();
+            final var relation = bom.getRelations().stream().findFirst().orElseThrow();
+            assertThat(relation.getFrom()).isEqualTo(bom.getPackages().get(0));
+            assertThat(relation.getTo()).isEqualTo(pkg);
+            assertThat(relation.getType()).isEqualTo(Relation.Type.DEPENDS_ON);
         }
 
         @Test

--- a/src/test/java/com/philips/research/spdxbuilder/persistence/blackduck/PackageIdentifierTest.java
+++ b/src/test/java/com/philips/research/spdxbuilder/persistence/blackduck/PackageIdentifierTest.java
@@ -13,8 +13,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class PackageIdentifierTest {
     @Test
-        // (Formats are based on external namespaces list provided by Black Duck.)
     void decodesFormats() {
+        // (Formats are based on external namespaces list provided by Black Duck.)
         assertIdentifier("alpine", "name/version/architecture", "alpine/name@version");
         // alt_linux
         // anaconda


### PR DESCRIPTION
Earlier I assumed that components without any origins represented e.g. directory structures. Analysis of various production projects showed that can also occur for binaries that have a proprietary origin, like a database driver. Omitting such components therefore risks missing important license constraints.

Solved by adding an "anonymous" (=without PURL) package for such components.

Earlier the case of a single component with multiple origins lead to adding these packages directly to the parent. To better match the data in Black Duck, it would be better to also add the component so the SPDX output better matches the Black Duck project.

Solved by inserting an "anonymous" (=without PURL) package for the component with the reported relationship. Separate packages (copying the metadata of the component) are added as plain dependencies for the component package.