### PR TITLE
Feature: Skip BD "Unknown License" licenses

### DIFF
--- a/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckComponent.java
+++ b/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckComponent.java
@@ -9,6 +9,7 @@ import com.github.packageurl.PackageURL;
 import com.philips.research.spdxbuilder.core.domain.License;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 interface BlackDuckComponent {
@@ -24,7 +25,7 @@ interface BlackDuckComponent {
 
     List<String> getUsages();
 
-    License getLicense();
+    Optional<License> getLicense();
 
     long getHierarchicalId();
 

--- a/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckReader.java
+++ b/src/main/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckReader.java
@@ -105,8 +105,8 @@ public class BlackDuckReader implements BomReader {
     }
 
     private void addSubproject(BillOfMaterials bom, Package parent, UUID projectId, UUID versionId, BlackDuckComponent component) {
-        final var pkg = new Package(null, component.getName(), component.getVersion())
-                .setConcludedLicense(component.getLicense());
+        final var pkg = new Package(null, component.getName(), component.getVersion());
+        component.getLicense().ifPresent(pkg::setConcludedLicense);
         bom.addPackage(pkg);
         exportRelation(bom, parent, pkg, component);
 
@@ -132,8 +132,8 @@ public class BlackDuckReader implements BomReader {
 
         final var details = client.getComponentDetails(component);
         final var pkg = new Package(purl)
-                .setConcludedLicense(component.getLicense())
                 .setSummary(component.getName());
+        component.getLicense().ifPresent(pkg::setConcludedLicense);
         details.getDescription().ifPresent(pkg::setDescription);
         details.getHomepage().ifPresent(pkg::setHomePage);
         bom.addPackage(pkg);

--- a/src/test/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckReaderTest.java
+++ b/src/test/java/com/philips/research/spdxbuilder/persistence/blackduck/BlackDuckReaderTest.java
@@ -115,7 +115,7 @@ class BlackDuckReaderTest {
             when(component.getName()).thenReturn(NAME);
             when(component.getVersion()).thenReturn(VERSION);
             when(component.getPackageUrls()).thenReturn(List.of(PACKAGE_URL));
-            when(component.getLicense()).thenReturn(LICENSE);
+            when(component.getLicense()).thenReturn(Optional.of(LICENSE));
             when(details.getDescription()).thenReturn(Optional.of(DESCRIPTION));
             when(details.getHomepage()).thenReturn(Optional.of(new URL(HOMEPAGE)));
         }
@@ -171,9 +171,8 @@ class BlackDuckReaderTest {
 
         @Test
         void exportsComponentPerOrigin() {
-            final var purl1 = PACKAGE_URL;
             final var purl2 = purlFrom("pkg:npm/second@2.0");
-            when(component.getPackageUrls()).thenReturn(List.of(purl1, purl2));
+            when(component.getPackageUrls()).thenReturn(List.of(PACKAGE_URL, purl2));
 
             reader.read(bom);
 
@@ -227,7 +226,7 @@ class BlackDuckReaderTest {
                 when(parent.getId()).thenReturn(PARENT_ID);
                 when(parent.getVersionId()).thenReturn(PARENT_VERSION_ID);
                 when(parent.getPackageUrls()).thenReturn(List.of(PARENT_PURL));
-                when(parent.getLicense()).thenReturn(License.NONE);
+                when(parent.getLicense()).thenReturn(Optional.of(License.NONE));
                 when(client.getComponentDetails(parent)).thenReturn(details);
             }
 


### PR DESCRIPTION
Whenever Black Duck lists a license as "Unknown License", the license is now skipped.

Note that this also works for: "Apache-2.0 AND Unknown License" (like encountered in a sample project).