### PR TITLE
Rename tree format 'spdx' to 'purl'

### DIFF
--- a/src/main/resources/treeformats.yml
+++ b/src/main/resources/treeformats.yml
@@ -91,7 +91,7 @@ formats:
     version:
       regex: "(\\S==|installed:\\s)([^\\]]+)\\]?$"
       group: 2
-  - format: spdx
+  - format: purl
     description: "Tree output of SPDX-Builder itself."
     tool: "SPDX-Builder <mode> --tree"
     type:

--- a/src/test/java/com/philips/research/spdxbuilder/persistence/tree/TreeFormatsTest.java
+++ b/src/test/java/com/philips/research/spdxbuilder/persistence/tree/TreeFormatsTest.java
@@ -175,8 +175,8 @@ class TreeFormatsTest {
         }
 
         @Test
-        void spdxTree() {
-            format.configure(parser, "spdx");
+        void purlTree() {
+            format.configure(parser, "purl");
 
             parse("TREE start =====",
                     "pkg:type/top@1.0",


### PR DESCRIPTION
# Current Situation

We can use `spdx-builder` to create a tree output with the dependencies in `purl`s.
f.e. 
``` bash
spdx-builder blackduck --tree <project> <version>
```
This generates a tree with purls f.e.:
```
TREE start ----------8<----------
pkg:generic/project-name@version
  pkg:generic/project-name@version%2F1.0 [dynamic]
  pkg:nuget/xunit.runner.visualstudio@2.4.3 [dynamic]
  pkg:nuget/xunit@2.4.1 [dynamic] (*)
TREE end ----------8<----------
```

We can use this output as input to `spdx-builder` again, to find extra information with `bom-base`.
```bash
cat tree.txt | spdx-builder tree -f spdx --kb http://localhost:8080 -o bom.spdx
```

The format here is called `spdx`. This is confusing, because one might think format `spdx` wants a spdx-file as input, instead of our custom tree format with purls.

# Proposal
Rename tree input format `spdx` to `purl` to avoid confusion.

Statement will look like:
```bash
cat tree.txt | spdx-builder tree -f purl --kb http://localhost:8080 -o bom.spdx
```
 