### PR TITLE
Add NuGet tree format

### DIFF
--- a/src/main/resources/treeformats.yml
+++ b/src/main/resources/treeformats.yml
@@ -52,16 +52,14 @@ formats:
       regex: "@([^@\\s]+)(\\s\\S+)?$"
       group: 1
   - format: nuget
-    description: "Nuget tree output"
-    tool: "See https://github.com/Brend-Smits/NugetTree"
+    description: "Tree output for NuGet based on tooling found in https://github.com/Brend-Smits/NugetTree"
+    tool: "dotnet src/NugetTree/bin/Debug/netcoreapp3.1/NugetTree.dll \"NugetTree.sln\" -t"
     types:
       "": "nuget"
     name:
-      regex: "([^ ]*)"
-      group: 1
+      regex: "(^\\S+)"
     version:
-      regex: "(?<= )(\\d.+)"
-      group: 1
+      regex: "\\s(\\S+)"
   - format: rust
     description: "Default Rust (=Cargo) tree output"
     tool: "cargo tree -e no-dev,no-build --locked"

--- a/src/main/resources/treeformats.yml
+++ b/src/main/resources/treeformats.yml
@@ -36,15 +36,6 @@ formats:
       group: 1
     start: "^runtimeClasspath" # Only runtime dependencies
     end: "^\\s*$" # Empty line
-  - format: nuget
-    description: "Nuget tree output"
-    tool: "See https://github.com/Brend-Smits/NugetTree"
-    name:
-      regex: "(?<= ) ([^ ]*)"
-      group: 1
-    version:
-      regex: "(?<= )(\d.+)"
-      group: 1
   - format: npm
     description: "Default NPM tree output"
     tool: "npm list --all --production"
@@ -59,6 +50,17 @@ formats:
       group: 2
     version:
       regex: "@([^@\\s]+)(\\s\\S+)?$"
+      group: 1
+  - format: nuget
+    description: "Nuget tree output"
+    tool: "See https://github.com/Brend-Smits/NugetTree"
+    types:
+      "": "nuget"
+    name:
+      regex: "([^ ]*)"
+      group: 1
+    version:
+      regex: "(?<= )(\\d.+)"
       group: 1
   - format: rust
     description: "Default Rust (=Cargo) tree output"

--- a/src/main/resources/treeformats.yml
+++ b/src/main/resources/treeformats.yml
@@ -36,6 +36,15 @@ formats:
       group: 1
     start: "^runtimeClasspath" # Only runtime dependencies
     end: "^\\s*$" # Empty line
+  - format: nuget
+    description: "Nuget tree output"
+    tool: "See https://github.com/Brend-Smits/NugetTree"
+    name:
+      regex: "(?<= ) ([^ ]*)"
+      group: 1
+    version:
+      regex: "(?<= )(\d.+)"
+      group: 1
   - format: npm
     description: "Default NPM tree output"
     tool: "npm list --all --production"

--- a/src/test/java/com/philips/research/spdxbuilder/persistence/tree/TreeFormatsTest.java
+++ b/src/test/java/com/philips/research/spdxbuilder/persistence/tree/TreeFormatsTest.java
@@ -84,6 +84,22 @@ class TreeFormatsTest {
         }
 
         @Test
+        void nuget() {
+            format.configure(parser, "nuget");
+
+            parse("ProjectName 1.0.0-dev",
+                    "---IdentityModel.AspNetCore 3.0.0.0",
+                    "AnotherProjectName 1.0.1",
+                    "---Coravel 4.0.2.0");
+
+            assertThat(bom.getPackages()).containsExactly(
+                    new Package("","ProjectName", "1.0.0-dev"),
+                    new Package("","IdentityModel.AspNetCore", "3.0.0.0"),
+                    new Package("","AnotherProjectName", "1.0.1"),
+                    new Package("","Coravel", "4.0.2.0"));
+        }
+
+        @Test
         void maven() {
             format.configure(parser, "maven");
 

--- a/src/test/java/com/philips/research/spdxbuilder/persistence/tree/TreeFormatsTest.java
+++ b/src/test/java/com/philips/research/spdxbuilder/persistence/tree/TreeFormatsTest.java
@@ -88,13 +88,15 @@ class TreeFormatsTest {
             format.configure(parser, "nuget");
 
             parse("ProjectName 1.0.0-dev",
-                    "---IdentityModel.AspNetCore 3.0.0.0",
+                    "---IdentityModel.AspNetCore7.1 3.0.0.0",
+                    "---xunit.extensibility.core 2.4.1.0 by xunit.core (2.4.1.0)",
                     "AnotherProjectName 1.0.1",
                     "---Coravel 4.0.2.0");
 
             assertThat(bom.getPackages()).containsExactly(
                     new Package("","ProjectName", "1.0.0-dev"),
-                    new Package("","IdentityModel.AspNetCore", "3.0.0.0"),
+                    new Package("","IdentityModel.AspNetCore7.1", "3.0.0.0"),
+                    new Package("","xunit.extensibility.core", "2.4.1.0"),
                     new Package("","AnotherProjectName", "1.0.1"),
                     new Package("","Coravel", "4.0.2.0"));
         }


### PR DESCRIPTION
This adds the ability to parse a NuGet tree that is outputted by a tool found here: https://github.com/Brend-Smits/NugetTree
If this pull request is approved, I can work on a proper new version of NugetTree without license risks on the philips-software repository. 

An example of the tree output that it produces can be found here, this outputs an example solution from [Octokit.NET](https://github.com/octokit/octokit.net):
https://gist.github.com/Brend-Smits/00fef41fbdcd742b859fa962a1356768

Without running Scancode (not installed on this machine, licenses will be a bit off for that reason), the SPDX file that it produces can be found here:
https://gist.github.com/Brend-Smits/a87cfba5cec20d34f800753a9ce3c261

Closes #83 

I'm unsure if the SPDX output is missing something, hoping @timovandeput could have a closer look.

How to test:
1. Download the first Gist of the tree output (or create your own).
2. Run spdx builder like you usually do, but with the nugget format:
```cat octokit-nuget-tree.txt | java -jar spdx-builder/build/libs/spdx-builder-v0.8.0.jar tree -f nuget --kb http://localhost:8080 -o octokit-nuget-tree.spdx```

How to create your own Nuget tree output:
1. Clone https://github.com/Brend-Smits/NugetTree
2. Make sure that you have dotnet installed on your machine (Core 3.1)
3. Navigate to the NugetTree directory and run ``dotnet build``. This will build the solution and place an executable .dll inside the ``src/NugetTree/bin/Debug/netcoreapp3.1/`` directory.
4. Execute the dll using the command ``` dotnet src/NugetTree/bin/Debug/netcoreapp3.1/NugetTree.dll "../octokit.net/Octokit.sln" -t``` Replace ../octokit.net/Octokit.sln with the path to the solution file.