### PR TITLE
Sort the written order of packages to SPDX file

### DIFF
--- a/src/main/java/com/philips/research/spdxbuilder/persistence/spdx/SpdxWriter.java
+++ b/src/main/java/com/philips/research/spdxbuilder/persistence/spdx/SpdxWriter.java
@@ -30,7 +30,7 @@ public class SpdxWriter implements BomProcessor, AutoCloseable {
             List.of("SHA1", "SHA224", "SHA256", "SHA384", "SHA512", "MD2", "MD4", "MD5", "MD6");
 
     private final OutputStream stream;
-    private final Map<Package, SpdxRef> identifiers = new HashMap<>();
+    private final Map<Package, SpdxRef> identifiers = new LinkedHashMap<>();
 
     private int nextId = 1;
 


### PR DESCRIPTION
At the moment in the SPDX file the Packages/Dependencies are in a random order and quite hard to follow.
Also the root package needs to be the start of the document. for this reason I tried to fix it with the order they are inserted.